### PR TITLE
Add petrelharp as recipe maintainer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,3 +68,4 @@ extra:
   recipe-maintainers:
     - benjeffery
     - jeromekelleher
+    - petrelharp


### PR DESCRIPTION
## Summary
- Add petrelharp as a recipe maintainer for tsinfer-feedstock

This PR adds petrelharp to the list of recipe maintainers for the tsinfer conda-forge package.